### PR TITLE
Add delay on successful crate version get.

### DIFF
--- a/src/crates.ts
+++ b/src/crates.ts
@@ -73,6 +73,7 @@ export async function awaitCrateVersion(
             versions &&
             versions.some(version_info => version_info.version === version)
         ) {
+            await delay(5000)
             return
         } else if (Date.now() - started > timeout) {
             throw new Error(


### PR DESCRIPTION
This introduces a (5-second) delay after successfully querying crates.io for a just-published crate. Since crates.io is not consistent, one query could find the crate, then a second query immediately following it might not. Should mostly fix #366 in practice.