### PR TITLE
Sort across all workspace deps (normal, dev & build)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ lib/**/*
 
 # Ignore cargo target
 __tests__/target/*
+# Ignore cargo lock
+__tests__/Cargo.lock

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Skips publishing of internal dependencies which does not updated
 - Publishes updated crates in right order according to dependencies
 - Awaits when published crate will be available in registry before publishing crates which depends from it
-- Works fine with workspaces without cyclic dependencies
+- Works fine in workspaces without cyclic dependencies
 
 ## Unimplemented features
 
@@ -27,6 +27,7 @@
 - `dry-run` Set to 'true' to bypass exec `cargo publish`
 - `check-repo` Set to 'false' to bypass check local packages for modifications since last published version
 - `publish-delay` Optional delay in milliseconds applied after publishing each package before publishing others
+- `no-verify` Set to `true` to bypass cyclic dependency detection and cargo packaging verification (uses `--no-verify`)
 
 Each local package (workspace member) potentially may be modified since last published version without
 corresponding version bump. This situation is dangerous and should be prevented. In order to do it this
@@ -38,9 +39,9 @@ pull-requests so you may simply disable this action for run in such cases (via `
 When you want to run action (say with `dry-run` set to `true`) prevent failing you may simply set `check-repo`
 to `false` too.
 
-**NOTE**: You should avoid set both `check-repo` and `dry-run` to `false`.
+**NOTE**: You should avoid setting both `check-repo` and `dry-run` to `false`.
 
-Usually you don't needed set `publish-delay` because this action ever checks availability of published
+Usually you don't need to set `publish-delay` because this action never checks availability of published
 packages before publishing others but in some cases it may help work around __crates.io__ inconsistency
 problems.
 

--- a/__tests__/Cargo.toml
+++ b/__tests__/Cargo.toml
@@ -1,8 +1,10 @@
 [workspace]
 members = [
   "pkg-sys",
+  "pkg-build",
   "pkg-lib",
   "pkg-bin",
+  'pkg-dev',
 ]
 
 [package]

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -8,7 +8,7 @@ const pkg_dir = __dirname
 test('find packages', async () => {
     const packages = await findPackages(pkg_dir)
 
-    expect(Object.keys(packages).length).toBe(4)
+    expect(Object.keys(packages).length).toBe(6)
 
     const pkg_all = packages['pkg-all']
     const pkg_sys = packages['pkg-sys']
@@ -29,7 +29,7 @@ test('find packages', async () => {
 
     expect(pkg_bin.path).toBe(join(pkg_dir, 'pkg-bin'))
     expect(pkg_bin.version).toBe('0.1.0')
-    expect(Object.keys(pkg_bin.dependencies).length).toBe(2)
+    expect(Object.keys(pkg_bin.dependencies).length).toBe(3)
 })
 
 test('check packages', async () => {
@@ -41,7 +41,14 @@ test('sort packages', async () => {
     const packages = await findPackages(pkg_dir)
     const sorted = sortPackages(packages)
 
-    expect(sorted).toEqual(['pkg-sys', 'pkg-lib', 'pkg-bin', 'pkg-all'])
+    expect(sorted).toEqual([
+        'pkg-sys',
+        'pkg-lib',
+        'pkg-build',
+        'pkg-dev',
+        'pkg-bin',
+        'pkg-all'
+    ])
 })
 
 test('get crate versions', async () => {

--- a/__tests__/pkg-bin/Cargo.toml
+++ b/__tests__/pkg-bin/Cargo.toml
@@ -5,3 +5,7 @@ version = "0.1.0"
 [dependencies]
 pkg-lib = { version = "0.1.0", path = "../pkg-lib" }
 clap = "^2"
+
+[dev-dependencies.pkg-dev]
+version = "0.1.0"
+path = "../pkg-dev"

--- a/__tests__/pkg-build/Cargo.toml
+++ b/__tests__/pkg-build/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pkg-build"
+version = "0.1.0"
+
+[dependencies]
+lazy_static = "1.0"
+
+[dependencies.pkg-lib]
+version = "0.1.0"
+path = "../pkg-lib"

--- a/__tests__/pkg-build/src/lib.rs
+++ b/__tests__/pkg-build/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn hello() {}

--- a/__tests__/pkg-dev/Cargo.toml
+++ b/__tests__/pkg-dev/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pkg-dev"
+version = "0.1.0"
+
+[dependencies]
+lazy_static = "1.0"
+
+[dev-dependencies.pkg-lib]
+version = "0.1.0"
+path = "../pkg-lib"
+
+[build-dependencies.pkg-build]
+version = "0.1.0"
+path = "../pkg-build"

--- a/__tests__/pkg-dev/Cargo.toml
+++ b/__tests__/pkg-dev/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 lazy_static = "1.0"
 
 [dev-dependencies.pkg-lib]
-version = "0.1.0"
 path = "../pkg-lib"
 
 [build-dependencies.pkg-build]

--- a/__tests__/pkg-dev/Cargo.toml
+++ b/__tests__/pkg-dev/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 [dependencies]
 lazy_static = "1.0"
 
+# test that local cyclic dev-deps are allowed using paths
 [dev-dependencies.pkg-lib]
 path = "../pkg-lib"
 

--- a/__tests__/pkg-dev/src/lib.rs
+++ b/__tests__/pkg-dev/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn hello() {}

--- a/__tests__/pkg-dev/test/tests.rs
+++ b/__tests__/pkg-dev/test/tests.rs
@@ -1,0 +1,2 @@
+#[test]
+fn integ_test() { }

--- a/__tests__/pkg-lib/Cargo.toml
+++ b/__tests__/pkg-lib/Cargo.toml
@@ -8,3 +8,7 @@ lazy_static = "1.0"
 [dependencies.pkg-sys]
 version = "0.1.0"
 path = "../pkg-sys"
+
+# test that local cyclic dev-deps are allowed using paths
+[dev-dependencies.pkg-dev]
+path = "../pkg-dev"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-crates",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "GitHub action to get easy publishing of Rust crates",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-crates",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "private": true,
   "description": "GitHub action to get easy publishing of Rust crates",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ async function run(): Promise<void> {
     const dry_run = getBooleanInput('dry-run')
     const check_repo = getBooleanInput('check-repo')
     const publish_delay = getIntegerInput('publish-delay')
+    const no_verify = getBooleanInput('no-verify')
 
     const env: EnvVars = {...(process.env as EnvVars)}
     if (registry_token) {
@@ -65,13 +66,21 @@ async function run(): Promise<void> {
             )
         }
 
-        info(`Sorting packages according to dependencies`)
-        const sorted_packages = sortPackages(packages)
+        let sorted_packages
+        if (!no_verify) {
+            info(`Sorting packages according to dependencies`)
+            sorted_packages = sortPackages(packages)
+        } else {
+            sorted_packages = Object.keys(packages)
+        }
 
         for (const package_name of sorted_packages) {
             const package_info = packages[package_name]
             if (!package_info.published) {
                 const exec_args = ['publish', ...args]
+                if (no_verify) {
+                    exec_args.push('--no-verify')
+                }
                 const exec_opts: ExecOptions = {
                     cwd: package_info.path,
                     env


### PR DESCRIPTION
This PR updates the action to support ordering across all categories of dependencies, rather than just normal dependencies like before. Now if you have crates in your workspace used for integration testing or proc-macros at build time, they will publish in the correct order before their dependents.

closes #305 