### PR TITLE
add default config option for no-verify

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   publish-delay:
     description: 'Extra post publish delay (milliseconds)'
     default: 0
+  no-verify:
+    description: 'Disable cargo publish validation and cyclic dependency checks'
+    default: 'false'
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Missed a default setting for the new `no-verify` option in the github action yaml.

fixes: https://github.com/katyo/publish-crates/issues/412