### PR TITLE
Execute a dry run of `cargo publish` when `dry-run` is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - `path` Sets path to crate or workspace ('.' by default)
 - `args` Extra arguments for `cargo publish` command
 - `registry-token` Cargo registry token (not used when `dry-run: true`)
-- `dry-run` Set to `true` to bypass exec `cargo publish`
+- `dry-run` Set to `true` to do a dry run exec of `cargo publish`
 - `check-repo` Set to `false` to bypass check local packages for modifications since last published version
 - `publish-delay` Optional delay in milliseconds applied after publishing each package before publishing others
 - `no-verify` Set to `true` to bypass cyclic dependency detection and cargo packaging verification (uses `--no-verify`)

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: 'Cargo registry token'
     default: ''
   dry-run:
-    description: 'Skip execution cargo publish'
+    description: 'Execute dry run of cargo publish'
     default: 'false'
   check-repo:
     description: 'Check repository consistency'

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,13 +106,11 @@ async function run(): Promise<void> {
                     env
                 }
                 if (dry_run) {
-                    const args_str = exec_args.join(' ')
-                    warning(
-                        `Skipping exec 'cargo ${args_str}' in '${package_info.path}' due to 'dry-run: true'`
-                    )
-                    warning(
-                        `Skipping awaiting when '${package_name} ${package_info.version}' will be available due to 'dry-run: true'`
-                    )
+                    exec_args.push('--dry-run')
+                    info(`Dry run publishing package '${package_name}'`)
+                    await exec('cargo', exec_args, exec_opts)
+                    await awaitCrateVersion(package_name, package_info.version)
+                    info(`Dry run publishing package '${package_name}' successful`)
                 } else {
                     info(`Publishing package '${package_name}'`)
                     await exec('cargo', exec_args, exec_opts)


### PR DESCRIPTION
The `cargo publish` command accepts a `--dry-run` argument that does does all the packaging checks on the crate except actually publishing the crate.

This action currently skip execution of `cargo publish` when its `dry-run` property is set. I propose to change this behavior and execute `cargo publish --dry-run` instead, so that we get the benefits of the checks that Cargo does.

Note that it is currently not possible to get the proposed behavior by specifying `args: --dry-run` because the await for the published package will fail.

Let me know what you think!