### PR TITLE
Fix type mismatch in GraphQL query

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ steps:
           dry-run: true
 ```
 
-Preventing failing on pull requests by disabling repository consistency check:
+Do all checks in both push and pull requests, but only publish on push:
 
 ```yaml
 steps:
@@ -94,8 +94,7 @@ steps:
           override: true
     - uses: katyo/publish-crates@v2
       with:
-          dry-run: true
-          check-repo: ${{ github.event_name == 'push' }}
+          dry-run: ${{ github.event_name != 'push' }}
 ```
 
 Prevent failing when there is no new version to publish:

--- a/src/github.ts
+++ b/src/github.ts
@@ -51,7 +51,7 @@ export async function lastCommitDate(
     try {
         result = await github.graphql(
             `
-query lastCommitDate($owner: String!, $repo: String!, $sha: String!, $path: String!) {
+query lastCommitDate($owner: String!, $repo: String!, $sha: GitObjectID!, $path: String!) {
     repository(owner: $owner, name: $repo) {
         object(oid: $sha) {
             ... on Commit {


### PR DESCRIPTION
Since I've never done GraphQL stuff before, it seems that I got the query slightly wrong. Resulting in
```
Error: Unable to determine latest modification time for local package 'package' due to: 'Error: Unable to retrieve history from GitHub due to: GraphqlResponseError: Request failed due to following response errors:
 - Type mismatch on variable $sha and argument oid (String! / GitObjectID)'
```

Sorry about that. This PR fixes the issue. Unclear why it didn't cause the tests to fail.