### PR TITLE
Use exit code to detect errors in cargo metadata

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -67,7 +67,7 @@ export async function findPackages(
     let output = ''
     let exec_error = ''
 
-    await exec(command, args, {
+    const exit_code = await exec(command, args, {
         listeners: {
             stdout: (data: Buffer) => {
                 output += data.toString('utf8')
@@ -78,7 +78,7 @@ export async function findPackages(
         }
     })
 
-    if (exec_error.length > 0) {
+    if (exit_code !== 0) {
         throw new Error(
             `During "cargo metadata" execution got an error: '${exec_error}'`
         )


### PR DESCRIPTION
cargo often prints outputs to stderr, even when there is no error. This change switches to using the exit code to detect if the `cargo metadata` command ran into an error.

The concrete setup in which this was causing an issue: if a [`rust-toolchain`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) file is present in a project specifying a different toolchain than default, cargo will first download the corresponding toolchain before actually getting the metadata, unfortunately this prints output to stderr (e.g. `info: syncing channel updates for 'nightly-2023-03-08-x86_64-unknown-linux-gnu'`). Ofc one could prefetch it in a previous action, but that shouldn't be necessary.