### PR TITLE
check_repo: ignore unpublished local changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,9 @@ async function run(): Promise<void> {
             package_errors = package_errors.filter(
                 ({kind}) => kind !== 'unable-to-get-commit-date'
             )
+            package_errors = package_errors.filter(
+                ({kind}) => kind !== 'has-unpublished-changes'
+            )
         }
 
         if (package_errors.length > 0) {


### PR DESCRIPTION
To allow force ignoring unpublished local changes as we might not be really publishing a release when running this action.